### PR TITLE
Feat: Add litellm_key_spend metric

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ RUN apt-get update && \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Add Tini
+# Add Tini (multi-arch)
+ARG TARGETARCH
 ENV TINI_VERSION=v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
 RUN chmod +x /tini
 
 # Copy requirements first to leverage Docker cache

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+# Name of the Docker image
+IMAGE_NAME ?= litellm-exporter:local
+CONTAINER_NAME ?= litellm-exporter
+PORT ?= 9090
+
+.PHONY: build run run-detached stop logs clean
+
+## Build the Docker image for local development
+build:
+	docker build -t $(IMAGE_NAME) .
+
+## Run the container interactively (requires .env file)
+run:
+	@if [ ! -f .env ]; then \
+		echo ".env file is required but was not found!"; \
+		exit 1; \
+	fi; \
+	docker run --rm -it --env-file .env \
+		-p $(PORT):9090 \
+		--name $(CONTAINER_NAME) \
+		$(IMAGE_NAME)
+
+## Run the container in detached mode (requires .env file)
+run-detached:
+	@if [ ! -f .env ]; then \
+		echo ".env file is required but was not found!"; \
+		exit 1; \
+	fi; \
+	docker run -d --env-file .env \
+		-p $(PORT):9090 \
+		--name $(CONTAINER_NAME) \
+		$(IMAGE_NAME)
+
+## Stop and remove the container if running
+stop:
+	-docker stop $(CONTAINER_NAME) || true
+	-docker rm $(CONTAINER_NAME) || true
+
+## Show logs from the running container
+logs:
+	docker logs -f $(CONTAINER_NAME)
+
+## Remove the local Docker image
+clean:
+	-docker rmi $(IMAGE_NAME) || true

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This exporter provides comprehensive Prometheus metrics for LiteLLM, exposing us
 - `litellm_team_spend`: Spend by team and model (labels: team_id, team_alias, model)
 - `litellm_org_spend`: Spend by organization and model (labels: organization_id, organization_alias, model)
 - `litellm_tag_spend`: Spend by request tag
+- `litellm_key_spend`: Spend by API key and model (labels: key_name, key_alias, model)
 
 ### Token Metrics
 - `litellm_total_tokens`: Total tokens used by model
@@ -304,6 +305,8 @@ Here are some example Prometheus queries for creating Grafana dashboards:
 - Spend by model: `sum by (model) (litellm_total_spend)`
 - Team spend by alias: `sum by (team_alias) (litellm_team_spend)`
 - Organization spend by alias: `sum by (organization_alias) (litellm_org_spend)`
+- API key spend by alias: `sum by (key_alias) (litellm_key_spend)`
+- API key spend by key name: `sum by (key_name) (litellm_key_spend)`
 
 ### Performance Monitoring
 - Request latency: `rate(litellm_request_duration_seconds_sum[5m]) / rate(litellm_request_duration_seconds_count[5m])`

--- a/README.md
+++ b/README.md
@@ -232,6 +232,58 @@ export METRICS_ERROR_WINDOW=1h
 python litellm_exporter.py
 ```
 
+## Local Docker Build & Test (for Development)
+
+To build and test the Docker container locally, use the provided Makefile for a streamlined workflow. This approach allows you to quickly build and test the Docker image in your local environment, streamlining development and troubleshooting.
+
+### Prerequisites
+- Docker installed and running
+- A valid `.env` file in the project root (see [Configuration](#configuration) for required variables)
+
+### Build the Docker Image
+```bash
+make build
+```
+This will build the image as `litellm-exporter:local` by default. You can override the image name if needed:
+```bash
+make build IMAGE_NAME=my-custom-image:dev
+```
+
+### Run the Container (Interactive)
+```bash
+make run
+```
+This will start the container interactively, mapping port 9090 and loading environment variables from `.env`.
+
+### Run the Container (Detached)
+```bash
+make run-detached
+```
+This will start the container in the background. To view logs:
+```bash
+make logs
+```
+
+### Stop and Clean Up
+```bash
+make stop
+```
+This stops and removes the running container. To remove the local image as well:
+```bash
+make clean
+```
+
+### Customization
+You can override the following variables at runtime:
+- `IMAGE_NAME` (default: `litellm-exporter:local`)
+- `CONTAINER_NAME` (default: `litellm-exporter`)
+- `PORT` (default: `9090`)
+
+Example:
+```bash
+make run-detached IMAGE_NAME=my-image:dev CONTAINER_NAME=litellm-dev PORT=8080
+```
+
 ## Prometheus Configuration
 
 Add the following to your `prometheus.yml`:

--- a/src/litellm_exporter/__init__.py
+++ b/src/litellm_exporter/__init__.py
@@ -1,14 +1,17 @@
+import logging
 import os
 import time
-import logging
+
 from prometheus_client import start_http_server
-from .config import MetricsConfig, DatabaseConfig
+
+from .config import DatabaseConfig, MetricsConfig
 from .database import DatabaseConnection
 from .metrics import LiteLLMMetrics, MetricsCollector
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
 
 def main():
     # Initialize configurations
@@ -21,11 +24,13 @@ def main():
     collector = MetricsCollector(db_connection, metrics, metrics_config)
 
     # Start the metrics server
-    metrics_port = int(os.getenv('METRICS_PORT', '9090'))
+    metrics_port = int(os.getenv("METRICS_PORT", "9090"))
     start_http_server(metrics_port)
     logger.info(f"Metrics server started on port {metrics_port}")
-    logger.info(f"Using time windows: spend={metrics_config.spend_window}, "
-               f"request={metrics_config.request_window}, error={metrics_config.error_window}")
+    logger.info(
+        f"Using time windows: spend={metrics_config.spend_window}, "
+        f"request={metrics_config.request_window}, error={metrics_config.error_window}"
+    )
     logger.info(f"Metrics update interval: {metrics_config.update_interval} seconds")
 
     # Update metrics based on configured interval
@@ -33,5 +38,6 @@ def main():
         collector.update_all_metrics()
         time.sleep(metrics_config.update_interval)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/src/litellm_exporter/__main__.py
+++ b/src/litellm_exporter/__main__.py
@@ -1,4 +1,4 @@
 from . import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/litellm_exporter/config/__init__.py
+++ b/src/litellm_exporter/config/__init__.py
@@ -1,18 +1,27 @@
 import os
 
+
 class MetricsConfig:
     def __init__(self):
         # Time windows for different types of metrics
-        self.spend_window = os.getenv('METRICS_SPEND_WINDOW', '30d')  # Default 30 days for spend metrics
-        self.request_window = os.getenv('METRICS_REQUEST_WINDOW', '24h')  # Default 24 hours for request metrics
-        self.error_window = os.getenv('METRICS_ERROR_WINDOW', '1h')  # Default 1 hour for error metrics
-        self.update_interval = int(os.getenv('METRICS_UPDATE_INTERVAL', '15'))  # Default 15 seconds for metrics update
+        self.spend_window = os.getenv(
+            "METRICS_SPEND_WINDOW", "30d"
+        )  # Default 30 days for spend metrics
+        self.request_window = os.getenv(
+            "METRICS_REQUEST_WINDOW", "24h"
+        )  # Default 24 hours for request metrics
+        self.error_window = os.getenv(
+            "METRICS_ERROR_WINDOW", "1h"
+        )  # Default 1 hour for error metrics
+        self.update_interval = int(
+            os.getenv("METRICS_UPDATE_INTERVAL", "15")
+        )  # Default 15 seconds for metrics update
 
         # Convert time window strings to PostgreSQL intervals
         self.time_windows = {
-            'spend': self._parse_time_window(self.spend_window),
-            'request': self._parse_time_window(self.request_window),
-            'error': self._parse_time_window(self.error_window)
+            "spend": self._parse_time_window(self.spend_window),
+            "request": self._parse_time_window(self.request_window),
+            "error": self._parse_time_window(self.error_window),
         }
 
     def _parse_time_window(self, window: str) -> str:
@@ -20,23 +29,22 @@ class MetricsConfig:
         unit = window[-1].lower()
         value = int(window[:-1])
 
-        units = {
-            'd': 'days',
-            'h': 'hours',
-            'm': 'minutes'
-        }
+        units = {"d": "days", "h": "hours", "m": "minutes"}
 
         if unit not in units:
-            raise ValueError(f"Invalid time window unit: {unit}. Use 'd' for days, 'h' for hours, or 'm' for minutes.")
+            raise ValueError(
+                f"Invalid time window unit: {unit}. Use 'd' for days, 'h' for hours, or 'm' for minutes."
+            )
 
         return f"{value} {units[unit]}"
 
+
 class DatabaseConfig:
     def __init__(self):
-        self.host = os.getenv('LITELLM_DB_HOST', 'localhost')
-        self.port = os.getenv('LITELLM_DB_PORT', '5432')
-        self.name = os.getenv('LITELLM_DB_NAME', 'litellm')
-        self.user = os.getenv('LITELLM_DB_USER', 'postgres')
-        self.password = os.getenv('LITELLM_DB_PASSWORD', '')
-        self.min_connections = int(os.getenv('DB_MIN_CONNECTIONS', '1'))
-        self.max_connections = int(os.getenv('DB_MAX_CONNECTIONS', '10'))
+        self.host = os.getenv("LITELLM_DB_HOST", "localhost")
+        self.port = os.getenv("LITELLM_DB_PORT", "5432")
+        self.name = os.getenv("LITELLM_DB_NAME", "litellm")
+        self.user = os.getenv("LITELLM_DB_USER", "postgres")
+        self.password = os.getenv("LITELLM_DB_PASSWORD", "")
+        self.min_connections = int(os.getenv("DB_MIN_CONNECTIONS", "1"))
+        self.max_connections = int(os.getenv("DB_MAX_CONNECTIONS", "10"))

--- a/src/litellm_exporter/database/__init__.py
+++ b/src/litellm_exporter/database/__init__.py
@@ -1,14 +1,17 @@
 import logging
-import psycopg2
-from psycopg2.extras import RealDictCursor
-from psycopg2 import pool
+from typing import Any, Dict, Optional
+
 import backoff
-from typing import Optional, Dict, Any
+import psycopg2
+from psycopg2 import pool
+from psycopg2.extras import RealDictCursor
+
 from ..config import DatabaseConfig
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
 
 class DatabaseConnection:
     def __init__(self, config: DatabaseConfig):
@@ -25,7 +28,7 @@ class DatabaseConnection:
                 port=self.config.port,
                 database=self.config.name,
                 user=self.config.user,
-                password=self.config.password
+                password=self.config.password,
             )
             logger.info("Database connection pool created successfully")
         except Exception as e:
@@ -33,7 +36,9 @@ class DatabaseConnection:
             raise
 
     @backoff.on_exception(backoff.expo, Exception, max_tries=5)
-    def execute_query(self, query: str, params: Optional[Dict[str, Any]] = None) -> list:
+    def execute_query(
+        self, query: str, params: Optional[Dict[str, Any]] = None
+    ) -> list:
         conn = None
         cur = None
         try:

--- a/src/litellm_exporter/metrics/__init__.py
+++ b/src/litellm_exporter/metrics/__init__.py
@@ -11,180 +11,248 @@ from ..queries import MetricQueries
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 class LiteLLMMetrics:
     def __init__(self):
         # Spend metrics
-        self.total_spend = Gauge('litellm_total_spend', 'Total spend across all users', ['model'])
-        self.user_spend = Gauge('litellm_user_spend', 'Spend by user', ['user_id', 'user_alias', 'model'])
-        self.team_spend = Gauge('litellm_team_spend', 'Spend by team', ['team_id', 'team_alias', 'model'])
-        self.org_spend = Gauge('litellm_org_spend', 'Spend by organization', ['organization_id', 'organization_alias', 'model'])
+        self.total_spend = Gauge(
+            "litellm_total_spend", "Total spend across all users", ["model"]
+        )
+        self.user_spend = Gauge(
+            "litellm_user_spend", "Spend by user", ["user_id", "user_alias", "model"]
+        )
+        self.team_spend = Gauge(
+            "litellm_team_spend", "Spend by team", ["team_id", "team_alias", "model"]
+        )
+        self.org_spend = Gauge(
+            "litellm_org_spend",
+            "Spend by organization",
+            ["organization_id", "organization_alias", "model"],
+        )
 
         # Token metrics
-        self.total_tokens = Gauge('litellm_total_tokens', 'Total tokens used', ['model'])
-        self.prompt_tokens = Gauge('litellm_prompt_tokens', 'Prompt tokens used', ['model'])
-        self.completion_tokens = Gauge('litellm_completion_tokens', 'Completion tokens used', ['model'])
+        self.total_tokens = Gauge(
+            "litellm_total_tokens", "Total tokens used", ["model"]
+        )
+        self.prompt_tokens = Gauge(
+            "litellm_prompt_tokens", "Prompt tokens used", ["model"]
+        )
+        self.completion_tokens = Gauge(
+            "litellm_completion_tokens", "Completion tokens used", ["model"]
+        )
 
         # Request metrics
-        self.requests_total = Gauge('litellm_requests_total', 'Total number of requests', ['model'])
-        self.cache_hits = Gauge('litellm_cache_hits_total', 'Total number of cache hits', ['model'])
-        self.cache_misses = Gauge('litellm_cache_misses_total', 'Total number of cache misses', ['model'])
+        self.requests_total = Gauge(
+            "litellm_requests_total", "Total number of requests", ["model"]
+        )
+        self.cache_hits = Gauge(
+            "litellm_cache_hits_total", "Total number of cache hits", ["model"]
+        )
+        self.cache_misses = Gauge(
+            "litellm_cache_misses_total", "Total number of cache misses", ["model"]
+        )
 
         # Rate limit metrics
-        self.tpm_limit = Gauge('litellm_tpm_limit', 'Tokens per minute limit', ['entity_type', 'entity_id', 'entity_alias'])
-        self.rpm_limit = Gauge('litellm_rpm_limit', 'Requests per minute limit', ['entity_type', 'entity_id', 'entity_alias'])
-        self.parallel_requests = Gauge('litellm_parallel_requests', 'Maximum parallel requests', ['entity_type', 'entity_id', 'entity_alias'])
+        self.tpm_limit = Gauge(
+            "litellm_tpm_limit",
+            "Tokens per minute limit",
+            ["entity_type", "entity_id", "entity_alias"],
+        )
+        self.rpm_limit = Gauge(
+            "litellm_rpm_limit",
+            "Requests per minute limit",
+            ["entity_type", "entity_id", "entity_alias"],
+        )
+        self.parallel_requests = Gauge(
+            "litellm_parallel_requests",
+            "Maximum parallel requests",
+            ["entity_type", "entity_id", "entity_alias"],
+        )
 
         # Budget metrics
-        self.budget_utilization = Gauge('litellm_budget_utilization', 'Budget utilization percentage', ['entity_type', 'entity_id', 'entity_alias'])
-        self.max_budget = Gauge('litellm_max_budget', 'Maximum budget', ['entity_type', 'entity_id', 'entity_alias'])
-        self.soft_budget = Gauge('litellm_soft_budget', 'Soft budget limit', ['entity_type', 'entity_id', 'entity_alias'])
-        self.budget_reset = Gauge('litellm_budget_reset_time', 'Time until budget reset in seconds', ['entity_type', 'entity_id', 'entity_alias'])
+        self.budget_utilization = Gauge(
+            "litellm_budget_utilization",
+            "Budget utilization percentage",
+            ["entity_type", "entity_id", "entity_alias"],
+        )
+        self.max_budget = Gauge(
+            "litellm_max_budget",
+            "Maximum budget",
+            ["entity_type", "entity_id", "entity_alias"],
+        )
+        self.soft_budget = Gauge(
+            "litellm_soft_budget",
+            "Soft budget limit",
+            ["entity_type", "entity_id", "entity_alias"],
+        )
+        self.budget_reset = Gauge(
+            "litellm_budget_reset_time",
+            "Time until budget reset in seconds",
+            ["entity_type", "entity_id", "entity_alias"],
+        )
 
         # Status metrics
-        self.blocked_status = Gauge('litellm_blocked_status', 'Entity blocked status', ['entity_type', 'entity_id', 'entity_alias'])
+        self.blocked_status = Gauge(
+            "litellm_blocked_status",
+            "Entity blocked status",
+            ["entity_type", "entity_id", "entity_alias"],
+        )
 
         # Key metrics
-        self.key_expiry = Gauge('litellm_key_expiry', 'Time until key expiry in seconds', ['key_name', 'key_alias'])
-        self.key_spend = Gauge('litellm_key_spend', 'Current spend for key', ['key_name', 'key_alias'])
+        self.key_expiry = Gauge(
+            "litellm_key_expiry",
+            "Time until key expiry in seconds",
+            ["key_name", "key_alias"],
+        )
         self.key_spend = Gauge(
             "litellm_key_spend", "Current spend for key", ["key_name", "key_alias"]
         )
 
+
 class MetricsCollector:
-    def __init__(self, db_connection: DatabaseConnection, metrics: LiteLLMMetrics, config: MetricsConfig):
+    def __init__(
+        self,
+        db_connection: DatabaseConnection,
+        metrics: LiteLLMMetrics,
+        config: MetricsConfig,
+    ):
         self.db = db_connection
         self.metrics = metrics
         self.config = config
 
     def update_spend_metrics(self):
-        query = MetricQueries.get_spend_metrics(self.config.time_windows['spend'])
+        query = MetricQueries.get_spend_metrics(self.config.time_windows["spend"])
         results = self.db.execute_query(
-            query,
-            {'time_window': self.config.time_windows['spend']}
+            query, {"time_window": self.config.time_windows["spend"]}
         )
 
         for row in results:
-            model = row['model'] or 'unknown'
+            model = row["model"] or "unknown"
 
             # Update model-level metrics
-            self.metrics.total_spend.labels(model=model).set(row['total_spend'] or 0)
-            self.metrics.total_tokens.labels(model=model).set(row['total_tokens'] or 0)
-            self.metrics.prompt_tokens.labels(model=model).set(row['prompt_tokens'] or 0)
-            self.metrics.completion_tokens.labels(model=model).set(row['completion_tokens'] or 0)
-            self.metrics.requests_total.labels(model=model).set(row['request_count'])
-            self.metrics.cache_hits.labels(model=model).set(row['cache_hits'] or 0)
-            self.metrics.cache_misses.labels(model=model).set(row['cache_misses'] or 0)
+            self.metrics.total_spend.labels(model=model).set(row["total_spend"] or 0)
+            self.metrics.total_tokens.labels(model=model).set(row["total_tokens"] or 0)
+            self.metrics.prompt_tokens.labels(model=model).set(
+                row["prompt_tokens"] or 0
+            )
+            self.metrics.completion_tokens.labels(model=model).set(
+                row["completion_tokens"] or 0
+            )
+            self.metrics.requests_total.labels(model=model).set(row["request_count"])
+            self.metrics.cache_hits.labels(model=model).set(row["cache_hits"] or 0)
+            self.metrics.cache_misses.labels(model=model).set(row["cache_misses"] or 0)
 
             # Update user/team/org specific metrics
-            if row['user_id']:
+            if row["user_id"]:
                 self.metrics.user_spend.labels(
-                    user_id=row['user_id'],
-                    user_alias=row['user_alias'] or 'none',
-                    model=model
-                ).set(row['total_spend'] or 0)
+                    user_id=row["user_id"],
+                    user_alias=row["user_alias"] or "none",
+                    model=model,
+                ).set(row["total_spend"] or 0)
 
-            if row['team_id']:
+            if row["team_id"]:
                 self.metrics.team_spend.labels(
-                    team_id=row['team_id'],
-                    team_alias=row['team_alias'] or 'none',
-                    model=model
-                ).set(row['total_spend'] or 0)
+                    team_id=row["team_id"],
+                    team_alias=row["team_alias"] or "none",
+                    model=model,
+                ).set(row["total_spend"] or 0)
 
-            if row['organization_id']:
+            if row["organization_id"]:
                 self.metrics.org_spend.labels(
-                    organization_id=row['organization_id'],
-                    organization_alias=row['organization_alias'] or 'none',
-                    model=model
-                ).set(row['total_spend'] or 0)
+                    organization_id=row["organization_id"],
+                    organization_alias=row["organization_alias"] or "none",
+                    model=model,
+                ).set(row["total_spend"] or 0)
 
     def update_rate_limits(self):
         results = self.db.execute_query(MetricQueries.get_rate_limits())
 
         for row in results:
-            entity_type = row['entity_type']
-            entity_id = row['entity_id']
-            entity_alias = row['entity_alias'] or 'none'
+            entity_type = row["entity_type"]
+            entity_id = row["entity_id"]
+            entity_alias = row["entity_alias"] or "none"
 
-            if row['tpm_limit']:
+            if row["tpm_limit"]:
                 self.metrics.tpm_limit.labels(
                     entity_type=entity_type,
                     entity_id=entity_id,
-                    entity_alias=entity_alias
-                ).set(row['tpm_limit'])
+                    entity_alias=entity_alias,
+                ).set(row["tpm_limit"])
 
-            if row['rpm_limit']:
+            if row["rpm_limit"]:
                 self.metrics.rpm_limit.labels(
                     entity_type=entity_type,
                     entity_id=entity_id,
-                    entity_alias=entity_alias
-                ).set(row['rpm_limit'])
+                    entity_alias=entity_alias,
+                ).set(row["rpm_limit"])
 
-            if row['max_parallel_requests']:
+            if row["max_parallel_requests"]:
                 self.metrics.parallel_requests.labels(
                     entity_type=entity_type,
                     entity_id=entity_id,
-                    entity_alias=entity_alias
-                ).set(row['max_parallel_requests'])
+                    entity_alias=entity_alias,
+                ).set(row["max_parallel_requests"])
 
-            if row['is_blocked']:
+            if row["is_blocked"]:
                 self.metrics.blocked_status.labels(
                     entity_type=entity_type,
                     entity_id=entity_id,
-                    entity_alias=entity_alias
+                    entity_alias=entity_alias,
                 ).set(1)
 
     def update_budget_metrics(self):
         results = self.db.execute_query(MetricQueries.get_budget_metrics())
 
         for row in results:
-            entity_type = row['entity_type']
-            entity_id = row['entity_id']
-            entity_alias = row['entity_alias'] or 'none'
+            entity_type = row["entity_type"]
+            entity_id = row["entity_id"]
+            entity_alias = row["entity_alias"] or "none"
 
-            if row['max_budget']:
+            if row["max_budget"]:
                 self.metrics.max_budget.labels(
                     entity_type=entity_type,
                     entity_id=entity_id,
-                    entity_alias=entity_alias
-                ).set(row['max_budget'])
+                    entity_alias=entity_alias,
+                ).set(row["max_budget"])
 
-                if row['current_spend']:
-                    utilization = (row['current_spend'] / row['max_budget']) * 100
+                if row["current_spend"]:
+                    utilization = (row["current_spend"] / row["max_budget"]) * 100
                     self.metrics.budget_utilization.labels(
                         entity_type=entity_type,
                         entity_id=entity_id,
-                        entity_alias=entity_alias
+                        entity_alias=entity_alias,
                     ).set(utilization)
 
-            if row['soft_budget']:
+            if row["soft_budget"]:
                 self.metrics.soft_budget.labels(
                     entity_type=entity_type,
                     entity_id=entity_id,
-                    entity_alias=entity_alias
-                ).set(row['soft_budget'])
+                    entity_alias=entity_alias,
+                ).set(row["soft_budget"])
 
-            if row['budget_reset_at']:
-                reset_seconds = (row['budget_reset_at'] - datetime.now()).total_seconds()
+            if row["budget_reset_at"]:
+                reset_seconds = (
+                    row["budget_reset_at"] - datetime.now()
+                ).total_seconds()
                 if reset_seconds > 0:
                     self.metrics.budget_reset.labels(
                         entity_type=entity_type,
                         entity_id=entity_id,
-                        entity_alias=entity_alias
+                        entity_alias=entity_alias,
                     ).set(reset_seconds)
 
     def update_key_metrics(self):
         results = self.db.execute_query(MetricQueries.get_key_metrics())
 
         for row in results:
-            key_name = row['key_name'] or 'none'
-            key_alias = row['key_alias'] or 'none'
+            key_name = row["key_name"] or "none"
+            key_alias = row["key_alias"] or "none"
 
-            if row['expires']:
-                expiry_seconds = (row['expires'] - datetime.now()).total_seconds()
+            if row["expires"]:
+                expiry_seconds = (row["expires"] - datetime.now()).total_seconds()
                 if expiry_seconds > 0:
                     self.metrics.key_expiry.labels(
-                        key_name=key_name,
-                        key_alias=key_alias
+                        key_name=key_name, key_alias=key_alias
                     ).set(expiry_seconds)
 
             if row["spend"]:

--- a/src/litellm_exporter/metrics/__init__.py
+++ b/src/litellm_exporter/metrics/__init__.py
@@ -1,9 +1,11 @@
-from datetime import datetime
 import logging
+from datetime import datetime
+
 from prometheus_client import Gauge
+
+from ..config import MetricsConfig
 from ..database import DatabaseConnection
 from ..queries import MetricQueries
-from ..config import MetricsConfig
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/src/litellm_exporter/queries/__init__.py
+++ b/src/litellm_exporter/queries/__init__.py
@@ -136,3 +136,17 @@ class MetricQueries:
             spend
         FROM "LiteLLM_VerificationToken"
         """
+
+    @staticmethod
+    def get_key_spend() -> str:
+        return """
+        SELECT
+            v.key_name,
+            v.key_alias,
+            SUM(l.spend) AS total_spend
+        FROM "LiteLLM_SpendLogs" l
+        LEFT JOIN "LiteLLM_VerificationToken" v ON l.api_key = v.token
+        WHERE l."startTime" >= NOW() - INTERVAL '30 days'
+        GROUP BY v.key_name, v.key_alias
+        ORDER BY total_spend DESC
+        """


### PR DESCRIPTION
Hi @ncecere,
Sorry for the many changes. I ran `black` and `isort` on the files, the commits are separated, so we can drop some if you don't agree with these changes.

This PR adds a new metric, `litellm_key_spend`, so the exporter also reports the cost per key, including virtual keys.

Best,
Richard